### PR TITLE
エントリーID抽出のバグを修正

### DIFF
--- a/server.py
+++ b/server.py
@@ -387,7 +387,9 @@ async def sync_all_entries_to_cache() -> Dict[str, Any]:
             return result
 
         for entry in result["entries"]:
-            entry_id = entry["id"].split("/")[-1]
+            # タグ形式のIDから数字のエントリーIDを抽出
+            # 例: "tag:blog.hatena.ne.jp,2013:blog-mtb_beta-10328749687202087533-6802418398316299513" -> "6802418398316299513"
+            entry_id = entry["id"].split("-")[-1]
             try:
                 # APIから取得してキャッシュに保存
                 entry_detail = await fetch_entry_from_api(entry_id)


### PR DESCRIPTION
## 概要
- はてなブログAPIのタグ形式IDから正しくエントリーIDを抽出するように修正
- 404エラーが発生していたキャッシュ同期機能を修復

## 修正内容
- `split("/")[-1]` から `split("-")[-1]` に変更
- タグ形式: `tag:blog.hatena.ne.jp,2013:blog-{HATENA_ID}-{エントリーID}`
- 最後のハイフン以降の数字部分が実際のエントリーID

## テスト計画
- [x] キャッシュ同期（`--update-cache`）が正常に動作することを確認
- [x] APIエラー（404）が発生しないことを確認
- [x] 記事の取得が正常に行えることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)